### PR TITLE
Kafka tombstones are deleted from ElasticSearch

### DIFF
--- a/src/main/java/io/confluent/connect/elasticsearch/BulkIndexingClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/BulkIndexingClient.java
@@ -47,7 +47,7 @@ public class BulkIndexingClient implements BulkClient<IndexableRecord, Bulk> {
   public Bulk bulkRequest(List<IndexableRecord> batch) {
     final Bulk.Builder builder = new Bulk.Builder();
     for (IndexableRecord record : batch) {
-      builder.addAction(record.toIndexRequest());
+      builder.addAction(record.toBulkableAction());
     }
     return builder.build();
   }

--- a/src/main/java/io/confluent/connect/elasticsearch/BulkIndexingClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/BulkIndexingClient.java
@@ -74,6 +74,8 @@ public class BulkIndexingClient implements BulkClient<IndexableRecord, Bulk> {
         } else if ("mapper_parse_exception".equals(errorType)) {
           retriable = false;
           errors.add(item.error);
+        } else if ("delete_failed_engine_exception".equals(errorType)) {
+          continue; // swallow failed delete operations, assumed to be delete on non-existent ID
         } else {
           errors.add(item.error);
         }

--- a/src/main/java/io/confluent/connect/elasticsearch/BulkIndexingClient.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/BulkIndexingClient.java
@@ -75,7 +75,9 @@ public class BulkIndexingClient implements BulkClient<IndexableRecord, Bulk> {
           retriable = false;
           errors.add(item.error);
         } else if ("delete_failed_engine_exception".equals(errorType)) {
-          continue; // swallow failed delete operations, assumed to be delete on non-existent ID
+          // swallow failed delete operations, assumed to be delete on non-existent ID
+          LOG.info("Swallowing error type {} for document ID {} and index {}", errorType, item.id, item.index);
+          continue;
         } else {
           errors.add(item.error);
         }

--- a/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/DataConverter.java
@@ -94,7 +94,12 @@ public class DataConverter {
       value = record.value();
     }
 
-    final String payload = new String(JSON_CONVERTER.fromConnectData(record.topic(), schema, value), StandardCharsets.UTF_8);
+    // Handle null values as tombstones. Cannot convert as JSON here.
+    String payload = null;
+    if (value != null) {
+      payload = new String(JSON_CONVERTER.fromConnectData(record.topic(), schema, value), StandardCharsets.UTF_8);
+    }
+
     final Long version = ignoreKey ? null : record.kafkaOffset();
     return new IndexableRecord(new Key(index, type, id), payload, version);
   }

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -55,7 +55,7 @@ public class ElasticsearchSinkTask extends SinkTask {
   // public for testing
   public void start(Map<String, String> props, JestClient client) {
     try {
-      log.info("Starting ElasticsearchSinkTask.");
+      log.info("Starting Bridg ElasticsearchSinkTask with tombstone support.");
 
       ElasticsearchSinkConnectorConfig config = new ElasticsearchSinkConnectorConfig(props);
       String type = config.getString(ElasticsearchSinkConnectorConfig.TYPE_NAME_CONFIG);

--- a/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
+++ b/src/main/java/io/confluent/connect/elasticsearch/ElasticsearchSinkTask.java
@@ -79,7 +79,7 @@ public class ElasticsearchSinkTask extends SinkTask {
       } else {
         List<String> address = config.getList(ElasticsearchSinkConnectorConfig.CONNECTION_URL_CONFIG);
         JestClientFactory factory = new JestClientFactory();
-        factory.setHttpClientConfig(new HttpClientConfig.Builder(address).multiThreaded(true).build());
+        factory.setHttpClientConfig(new HttpClientConfig.Builder(address).readTimeout(30000).multiThreaded(true).build());
         this.client = factory.getObject();
       }
 


### PR DESCRIPTION
Adds new support for Kafka compaction tombstones. 

When a key is present and the value is null the message is treated as a tombstone. A bulk delete action is created and added to the bulk actions.

### Tombstone Message Format

We're using the Confluent Avro encoders that make use of Schema Registry. Special care needs to be taken when publishing a tombstone message.

```
key.serializer=io.confluent.kafka.serializers.KafkaAvroSerializer
value.serializer=org.apache.kafka.common.serialization.ByteArraySerializer
```

The key needs to be Avro encoded in Confluent style so that it matches the key for non-tombstones. The value needs to use normal byte array so that only the naked null is put into the message value.

### Potential issues

* Currently no error handling or consideration for when the record does not exist.
* No tests